### PR TITLE
Add initial React app entry files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "1800-reborn",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "scripts": {
+    "start": "webpack serve --mode development --open",
+    "build": "webpack --mode production"
+  }
+}

--- a/src/App.js
+++ b/src/App.js
@@ -1,0 +1,18 @@
+import React, { useState } from 'react';
+import HomePage from './HomePage';
+
+function App() {
+  const [count, setCount] = useState(0);
+
+  const increment = () => setCount(count + 1);
+
+  return (
+    <div>
+      <h1>Welcome to the App</h1>
+      <button onClick={increment}>Click count: {count}</button>
+      <HomePage />
+    </div>
+  );
+}
+
+export default App;

--- a/src/HomePage.js
+++ b/src/HomePage.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function HomePage() {
+  return (
+    <div>
+      <h2>Home Page</h2>
+      <p>This is the home page content.</p>
+    </div>
+  );
+}
+
+export default HomePage;

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);


### PR DESCRIPTION
## Summary
- add React app entry `App.js` with basic state management
- create `HomePage` component
- provide `index.js` rendering entry point
- add minimal `package.json`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_68447da23ca8832184e3a680b9f3ebdf